### PR TITLE
Set the maximum threads to 32

### DIFF
--- a/lib/kb_IDBA/kb_IDBAImpl.py
+++ b/lib/kb_IDBA/kb_IDBAImpl.py
@@ -112,7 +112,9 @@ https://github.com/loneknightpy/idba - Version 1.1.3
 
     def exec_idba_ud(self, reads_data, params_in, outdir):
 
-        threads = psutil.cpu_count() * self.THREADS_PER_CORE
+        # This caused too much contention on our workers - threads = psutil.cpu_count() * self.THREADS_PER_CORE
+        # Statically setting to 32 threads for now
+        threads = 32
 
         if not os.path.exists(outdir):
             os.makedirs(outdir)


### PR DESCRIPTION
The maximum threads had been set to the number of cpu cores in the machine.  This caused contention as the cores are usually oversubscribed on our workers.